### PR TITLE
catch errors during generateMessage

### DIFF
--- a/lib/ses-transport.js
+++ b/lib/ses-transport.js
@@ -186,6 +186,10 @@ SESTransport.prototype.generateMessage = function (mailStream, callback) {
         chunks.push(chunk);
         chunklen += chunk.length;
     });
+    
+    mailStream.on('error', function(err) {
+        callback(err);
+    });
 
     mailStream.on('end', function () {
         callback(null, Buffer.concat(chunks, chunklen).toString());


### PR DESCRIPTION
Sending an email with an invalid attachment (http url with a 404 return code), creates an uncatchable exception. This pull request checks the mailStream for errors, and if so calls the callback with the err obj.

see also https://github.com/nodemailer/nodemailer-fetch/issues/1

thanks for merging!

