### PR TITLE
Fix processQueue with constant frequency

### DIFF
--- a/lib/ses-transport.js
+++ b/lib/ses-transport.js
@@ -80,19 +80,6 @@ SESTransport.prototype.send = function (mail, callback) {
  */
 SESTransport.prototype.processQueue = function () {
     if (this.sending) {
-        var timeDelta = Date.now() - this.startTime;
-
-        if (timeDelta >= 1000 / this.rateLimit) {
-            this.count = 0;
-            this.sending = false;
-            setImmediate(this.processQueue.bind(this));
-        } else {
-            this.count++;
-            setTimeout(function () {
-                this.sending = false;
-                this.processQueue();
-            }.bind(this), Math.ceil(1000 / this.rateLimit * this.count - timeDelta));
-        }
         return;
     }
 
@@ -101,7 +88,6 @@ SESTransport.prototype.processQueue = function () {
     }
 
     this.sending = true;
-    this.startTime = Date.now();
     var item = this.queue.shift();
 
     this.sendMessage(item.mail, function () {
@@ -113,6 +99,11 @@ SESTransport.prototype.processQueue = function () {
             });
         }
     }.bind(this));
+
+    setTimeout(function () {
+        this.sending = false;
+        this.processQueue();
+    }.bind(this), Math.ceil(1000 / this.rateLimit));
 };
 
 /**

--- a/lib/ses-transport.js
+++ b/lib/ses-transport.js
@@ -47,8 +47,6 @@ function SESTransport(options) {
     this.rateLimit = Number(options.rateLimit) || false;
     this.queue = [];
     this.sending = false;
-    this.startTime = 0;
-    this.count = 0;
 
     this.name = 'SES';
     this.version = packageData.version;


### PR DESCRIPTION
I have issues with the processQueue function, it sends more mails per seconds than I defined in my rateLimit parameter.
I propose another way to do it and this solution does not send more than `rateLimit` emails per seconds. Don't hesitate if you see any improvement.