### PR TITLE
Add optional Source parameter

### DIFF
--- a/lib/ses-transport.js
+++ b/lib/ses-transport.js
@@ -132,6 +132,9 @@ SESTransport.prototype.handleMessage = function (mail, raw, callback) {
             Data: new Buffer(raw, 'utf-8') // required
         }
     };
+    if (this.options.source) {
+        params.Source = this.options.source;
+    }
     this.ses.sendRawEmail(params, function (err, data) {
         this.responseHandler(err, mail, data, callback);
     }.bind(this));


### PR DESCRIPTION
By adding a source parameter in options (for instance `source: "user@example.com"`), every mail would be sent with this Source header. Therefore the bounce email notification would be sent to this email and not to the "from" email.
If there's an other way to have a from and a different source address with this module, I didn't find it.