### PR TITLE
Add maxConnections throttle for poor connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Where
     * **region** - *optional* Specify the region to send the service request to. Defaults to *us-east-1*. Not used if `options.ses` is set.
     * **httpOptions** - A set of options to pass to the low-level AWS HTTP request. See options in the [AWS-SES docs](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SES.html). Not used if `options.ses` is set.
     * **rateLimit** - *optional* Specify the amount of messages that [can be sent in 1 second](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/limits.html). For example if you want to send at most 5 messages in a second, set this value to 5. If you do not set it, rate limiting is not applied and messages are sent out immediately.
+    * **maxConnections** - *optional* Specify the maximum number of messages to be "in-flight" at any one point in time. Useful for preventing suffocation of an internet connection when sending lots of messages.
 
 ### Examples
 

--- a/lib/ses-transport.js
+++ b/lib/ses-transport.js
@@ -8,6 +8,8 @@ module.exports = function (options) {
     return new SESTransport(options);
 };
 
+var THROTTLE_DELAY = 5;
+
 /**
  * <p>Generates a Transport object for Amazon SES with aws-sdk</p>
  *
@@ -47,6 +49,8 @@ function SESTransport(options) {
     this.rateLimit = Number(options.rateLimit) || false;
     this.queue = [];
     this.sending = false;
+    this.currentConnections = 0;
+    this.maxConnections = Number(options.maxConnections) || Infinity;
 
     this.name = 'SES';
     this.version = packageData.version;
@@ -69,7 +73,11 @@ SESTransport.prototype.send = function (mail, callback) {
         });
         this.processQueue();
     } else {
-        this.sendMessage(mail, callback);
+        if (this.currentConnections < this.maxConnections) {
+            this.sendMessage(mail, callback);
+        } else {
+            setTimeout(this.send.bind(this, mail, callback), THROTTLE_DELAY);
+        }
     }
 };
 
@@ -98,9 +106,13 @@ SESTransport.prototype.processQueue = function () {
         }
     }.bind(this));
 
-    setTimeout(function () {
-        this.sending = false;
-        this.processQueue();
+    setTimeout(function sendNextMail() {
+        if (this.currentConnections < this.maxConnections) {
+            this.sending = false;
+            this.processQueue();
+        } else {
+            setTimeout(sendNextMail.bind(this), THROTTLE_DELAY);
+        }
     }.bind(this), Math.ceil(1000 / this.rateLimit));
 };
 
@@ -135,7 +147,9 @@ SESTransport.prototype.handleMessage = function (mail, raw, callback) {
     if (this.options.source) {
         params.Source = this.options.source;
     }
+    this.currentConnections++;
     this.ses.sendRawEmail(params, function (err, data) {
+        this.currentConnections--;
         this.responseHandler(err, mail, data, callback);
     }.bind(this));
 };
@@ -178,7 +192,7 @@ SESTransport.prototype.generateMessage = function (mailStream, callback) {
         chunks.push(chunk);
         chunklen += chunk.length;
     });
-    
+
     mailStream.on('error', function(err) {
         callback(err);
     });

--- a/lib/ses-transport.js
+++ b/lib/ses-transport.js
@@ -72,12 +72,10 @@ SESTransport.prototype.send = function (mail, callback) {
             callback: callback
         });
         this.processQueue();
+    } else if (this.currentConnections < this.maxConnections) {
+        this.sendMessage(mail, callback);
     } else {
-        if (this.currentConnections < this.maxConnections) {
-            this.sendMessage(mail, callback);
-        } else {
-            setTimeout(this.send.bind(this, mail, callback), THROTTLE_DELAY);
-        }
+        setTimeout(this.send.bind(this, mail, callback), THROTTLE_DELAY);
     }
 };
 

--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = function (w) {
+  return {
+    files: [
+      // Application code
+      { pattern: 'lib/**/*.js', load: false },
+      // Support files
+      { pattern: 'package.json', load: false }
+    ],
+    tests: [
+      'test/**/*.js'
+    ],
+    env: {
+      type: 'node'
+    },
+    testFramework: 'mocha'
+  };
+};


### PR DESCRIPTION
Adds a user-configurable maxConnections option (default value is Infinity, i.e. unlimited) to allow users to limit the maximum number of "in-flight" messages at any one time to prevent suffocation of poor connections.

I've tested the code and it has the desired effect:
- With *no maximum connections and a rate limit of 28*, I achieve a peak sending rate of around 7 messages per second, but that is very short lived and it quickly drops because more connections are being opened than are being closed so the quality of each connection suffers. By the end of the batch the overall send rate dropped to 1.5 messages per second!
- When I specify *10 maximum connections and a rate limit of 28* then I get a sustained send rate of 7 messages per second throughout the whole batch. No crazy slow downs.

Note that whilst it might come to mind to say "why don't you lower your send rate?", that's not really a viable option as the connection quality is not consistent. Some times of the day I can manage around 14 messages per second, other times I can barely manage 3. Also the size of the messages can affect the time they take to send. Limiting the number of in-flight connections is one way of ensuring that each connection has access to enough bandwidth / priority to get its job done without timing out.

If you want I can add unit tests for this feature but it will then be best for me to introduce a JS mock clock (something like zurvan or maybe even sinon's one might do) so that the tests don't take long to run.