### PR TITLE
Update to add SMTP envelope

### DIFF
--- a/lib/ses-transport.js
+++ b/lib/ses-transport.js
@@ -145,7 +145,7 @@ SESTransport.prototype.handleMessage = function (mail, raw, callback) {
     if (this.options.source) {
         params.Source = this.options.source;
     }
-     if(mail.data.Destinations){
+    if (mail.data.Destinations) {
         params.Destinations = mail.data.Destinations;
     }
     this.currentConnections++;

--- a/lib/ses-transport.js
+++ b/lib/ses-transport.js
@@ -145,6 +145,9 @@ SESTransport.prototype.handleMessage = function (mail, raw, callback) {
     if (this.options.source) {
         params.Source = this.options.source;
     }
+     if(mail.data.Destinations){
+        params.Destinations = mail.data.Destinations;
+    }
     this.currentConnections++;
     this.ses.sendRawEmail(params, function (err, data) {
         this.currentConnections--;


### PR DESCRIPTION
AWS API exposes the SMTP envelope settings through params.Destinations

This leaves the RFC message intact (appears to go to recipients x & y, but can be sent to recipient z instead).

Issue #22 